### PR TITLE
Fix: Correct unclosed comment in RegistrationHandlerTest.php

### DIFF
--- a/tests/Integration/RegistrationHandlerTest.php
+++ b/tests/Integration/RegistrationHandlerTest.php
@@ -256,3 +256,4 @@ function getAppDbConnection() {
 // The tests also need a way to assert redirects and messages, often by mocking header() and exit()
 // or by using PHPUnit features for testing HTTP output.
 ?>
+*/


### PR DESCRIPTION
Resolved a PHP ParseError (Unclosed '{') in tests/Integration/RegistrationHandlerTest.php by adding the missing '*/' to close a multi-line comment block at the end of the file.